### PR TITLE
feat: flat ir generation from mixing graph

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -216,6 +216,7 @@ dependencies = [
  "clap",
  "mixer-generator",
  "mixer-graph",
+ "mixer-ir",
 ]
 
 [[package]]
@@ -333,6 +334,14 @@ dependencies = [
  "pest",
  "pest_derive",
  "petgraph",
+]
+
+[[package]]
+name = "mixer-ir"
+version = "0.0.0"
+dependencies = [
+ "mixer-generator",
+ "mixer-graph",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,3 @@
 [workspace]
 resolver = "2"
-members = ["mixer-generator", "fluido", "mixer-graph"]
+members = ["mixer-generator", "fluido", "mixer-graph", "mixer-ir"]

--- a/fluido/Cargo.toml
+++ b/fluido/Cargo.toml
@@ -6,5 +6,6 @@ edition = "2021"
 [dependencies]
 mixer-generator = { path = "../mixer-generator/" }
 mixer-graph = { path = "../mixer-graph/" }
+mixer-ir = { path = "../mixer-ir/" }
 anyhow = "1.0.79"
 clap = { version = "4.5.0", features = ["derive"] }

--- a/fluido/src/main.rs
+++ b/fluido/src/main.rs
@@ -34,5 +34,10 @@ fn main() -> anyhow::Result<()> {
     println!("cost: {cost}");
     let dot = graph.dot();
     println!("{dot}");
+    let mut ir_builder = mixer_ir::ir_builder::IRBuilder::default();
+    let ir_ops = ir_builder.build_ir(graph);
+    for (op_index, op) in ir_ops.iter().enumerate() {
+        println!("{} : {}", op_index, op)
+    }
     Ok(())
 }

--- a/mixer-graph/src/graph.rs
+++ b/mixer-graph/src/graph.rs
@@ -3,17 +3,28 @@ use petgraph::graph::{DiGraph, NodeIndex};
 
 pub struct Graph {
     graph: DiGraph<Expr, ()>,
+    root: Option<NodeIndex>,
+}
+
+impl AsRef<DiGraph<Expr, ()>> for Graph {
+    fn as_ref(&self) -> &DiGraph<Expr, ()> {
+        &self.graph
+    }
 }
 
 impl Graph {
     fn new() -> Self {
         Self {
             graph: DiGraph::new(),
+            root: None,
         }
     }
 
     fn add_expr(&mut self, expr: &Expr) -> NodeIndex {
         let index = self.graph.add_node(expr.clone());
+        if self.root.is_none() {
+            self.root = Some(index);
+        }
 
         match expr {
             Expr::Number(_) => {}
@@ -25,6 +36,10 @@ impl Graph {
             }
         }
         index
+    }
+
+    pub fn root_node(&self) -> Option<NodeIndex> {
+        self.root
     }
 
     pub fn dot(&self) -> String {

--- a/mixer-ir/Cargo.toml
+++ b/mixer-ir/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "mixer-ir"
+version = "0.0.0"
+edition = "2021"
+
+[dependencies]
+mixer-graph = { path = "../mixer-graph/" }
+mixer-generator = { path = "../mixer-generator/" }

--- a/mixer-ir/src/ir.rs
+++ b/mixer-ir/src/ir.rs
@@ -1,0 +1,36 @@
+use mixer_generator::concentration::Concentration;
+
+#[derive(Debug, Clone)]
+/// Possible IR operations for mixlang.
+pub enum IROp {
+    // store value_to_store v_register_destination
+    Store((Operand, Operand)),
+    // mix in1_vreg in2_vreg, target_vreg
+    Mix((Operand, Operand, Operand)),
+}
+
+#[derive(Debug, Clone)]
+pub enum Operand {
+    Const(Concentration),
+    VirtualRegister(usize),
+}
+
+
+impl std::fmt::Display for IROp {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            IROp::Store(store) => write!(f, "store {} {}", store.0, store.1),
+            IROp::Mix(mix) => write!(f, "mix {} {} {}", mix.0, mix.1, mix.2),
+        }
+    }
+}
+
+
+impl std::fmt::Display for Operand {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Operand::Const(num) => write!(f, "{}", num),
+            Operand::VirtualRegister(v_reg) => write!(f, "%{}", v_reg),
+        }
+    }
+}

--- a/mixer-ir/src/ir_builder.rs
+++ b/mixer-ir/src/ir_builder.rs
@@ -1,0 +1,53 @@
+use crate::ir::{IROp, Operand};
+use mixer_generator::concentration::Concentration;
+use mixer_graph::{graph::Graph, parse::Expr};
+
+#[derive(Debug, Default)]
+pub struct IRBuilder {
+    context: IRContext,
+}
+
+#[derive(Debug, Default)]
+pub struct IRContext {
+    ir_output: Vec<IROp>,
+}
+
+impl IRBuilder {
+    pub fn build_ir(&mut self, graph: Graph) -> Vec<IROp> {
+        let root_node = graph.root_node().expect("missing root node in graph");
+        let expr = &graph.as_ref()[root_node];
+        self.compile_expr(expr.clone());
+        self.context.ir_output.clone()
+    }
+
+    /// Returns the expr's result v_reg.
+    pub fn compile_expr(&mut self, expr: Expr) -> usize {
+        match expr {
+            Expr::Mix(l_expr, r_expr) => self.compile_mix(*l_expr, *r_expr),
+            Expr::Number(concentration) => self.compile_number(concentration),
+        }
+    }
+
+    pub fn compile_number(&mut self, number: Concentration) -> usize {
+        let current_virtual_register_ix = self.context.ir_output.len();
+        let store_destination_v_reg = Operand::VirtualRegister(current_virtual_register_ix);
+        let value_to_store = Operand::Const(number);
+        let ir_op = IROp::Store((value_to_store, store_destination_v_reg));
+        self.context.ir_output.push(ir_op);
+        current_virtual_register_ix
+    }
+
+    pub fn compile_mix(&mut self, lhs: Expr, rhs: Expr) -> usize {
+        let lhs_vreg_ix = self.compile_expr(lhs);
+        let rhs_vreg_ix = self.compile_expr(rhs);
+        let current_virtual_register_ix = self.context.ir_output.len();
+        let lhs_vreg_operand = Operand::VirtualRegister(lhs_vreg_ix);
+        let rhs_vreg_operand = Operand::VirtualRegister(rhs_vreg_ix);
+        let target_vreg = Operand::VirtualRegister(current_virtual_register_ix);
+
+        let ir_op = IROp::Mix((lhs_vreg_operand, rhs_vreg_operand, target_vreg));
+
+        self.context.ir_output.push(ir_op);
+        current_virtual_register_ix
+    }
+}

--- a/mixer-ir/src/lib.rs
+++ b/mixer-ir/src/lib.rs
@@ -1,0 +1,2 @@
+pub mod ir;
+pub mod ir_builder;


### PR DESCRIPTION
Implements a way to generate flat ir from given mixing graph. 

For example:

```
0 : store 0.001 %0
1 : store 0.001 %1
2 : store 0 %2
3 : store 0 %3
4 : store 0 %4
5 : store 0 %5
6 : store 0.4 %6
7 : mix %5 %6 %5
8 : mix %4 %5 %4
9 : mix %3 %4 %3
10 : mix %2 %3 %2
11 : mix %1 %2 %1
12 : store 0 %12
13 : store 0 %13
14 : store 0 %14
15 : store 0 %15
16 : store 0.4 %16
17 : mix %15 %16 %15
18 : mix %14 %15 %14
19 : mix %13 %14 %13
20 : mix %12 %13 %12
21 : mix %1 %12 %1
22 : mix %0 %1 %0
```


from the following mixing graph:

![image](https://github.com/kayagokalp/fluido/assets/20915464/a0644bd1-a6d4-4d07-adc2-a0170cd54dc5)


which is equivalent to `(mix 0.001 (mix (mix 0.001 (mix 0 (mix 0 (mix 0 (mix 0 0.4))))) (mix 0 (mix 0 (mix 0 (mix 0 0.4))))))`
