### PR TITLE
chore: add z3 to nix flake

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -17,12 +17,13 @@
       in rec {
         # For `nix build` & `nix run`:
         defaultPackage = naersk'.buildPackage {
+	  buildInputs = with pkgs; [ z3 ];
           src = ./.;
         };
 
         # For `nix develop` (optional, can be skipped):
         devShell = pkgs.mkShell {
-          nativeBuildInputs = with pkgs; [ rustc cargo ];
+          nativeBuildInputs = with pkgs; [ rustc cargo z3 ];
         };
       }
     );


### PR DESCRIPTION
We will require z3 for graph coloring purposes around register allocation. Using our nix flake we can ensure it is installed in both dev and built environments at least for nix users.