### PR TITLE
fix: merge error in fludio bin main.rs, preventing sucessfull builds

### DIFF
--- a/fluido/src/main.rs
+++ b/fluido/src/main.rs
@@ -42,8 +42,6 @@ fn main() -> anyhow::Result<()> {
     let ir_ops = ir_builder.build_ir(graph);
 
     if args.show_ir {
-        let mut ir_builder = mixer_ir::ir_builder::IRBuilder::default();
-        let ir_ops = ir_builder.build_ir(graph);
         for (op_index, op) in ir_ops.iter().enumerate() {
             println!("{} : {}", op_index, op)
         }


### PR DESCRIPTION
Looks like there was a merge error in main.rs for fluido bin, causing builds to fail. #12 should be prioritized.