### PR TITLE
feat: saturate over fluids with concentration and volume information

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -304,7 +304,6 @@ name = "fluido-generation"
 version = "0.0.0"
 dependencies = [
  "anyhow",
- "clap",
  "egg",
  "fluido-types",
 ]
@@ -335,6 +334,7 @@ dependencies = [
 name = "fluido-types"
 version = "0.0.0"
 dependencies = [
+ "egg",
  "thiserror",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,9 @@
 [workspace]
 resolver = "2"
 members = ["fluido-generation", "fluido", "fluido-parse", "fluido-ir", "fluido-core", "fluido-types"]
+
+[workspace.dependencies]
+anyhow = "1.0.79"
+egg = "0.9.5"
+petgraph = "0.6.4"
+thiserror = "1.0.57"

--- a/fluido-core/Cargo.toml
+++ b/fluido-core/Cargo.toml
@@ -8,4 +8,4 @@ fluido-generation = { path = "../fluido-generation/" }
 fluido-ir = { path = "../fluido-ir" }
 fluido-parse = { path = "../fluido-parse" }
 fluido-types = { path = "../fluido-types" }
-thiserror = "1.0.57"
+thiserror = { workspace = true }

--- a/fluido-generation/Cargo.toml
+++ b/fluido-generation/Cargo.toml
@@ -4,7 +4,6 @@ version = "0.0.0"
 edition = "2021"
 
 [dependencies]
-anyhow = "1.0.79"
-clap = { version = "4.5.0", features = ["derive"] }
-egg = "0.9.5"
+anyhow = { workspace  = true }
+egg = { workspace = true }
 fluido-types = { path = "../fluido-types/" }

--- a/fluido-generation/src/lib.rs
+++ b/fluido-generation/src/lib.rs
@@ -1,58 +1,145 @@
 use egg::{rewrite as rw, *};
-use fluido_types::{concentration::Concentration, error::MixerGenerationError};
-use std::{collections::HashSet, hash::Hash, time::Duration};
+use fluido_types::{concentration::Concentration, error::MixerGenerationError, fluid::Fluid};
+use std::{collections::HashSet, time::Duration};
 
 define_language! {
     pub enum MixLang {
+        Vol(u64),
+        Concentration(Concentration),
         "mix" = Mix([Id; 2]),
-        Num(Concentration),
-        "+" = Add([Id; 2]),
-        "-" = Sub([Id; 2]),
+        "fluid" = Fluid([Id; 2]),
+        "c+" = ConcentrationAdd([Id; 2]),
+        "c-" = ConcentrationSub([Id; 2]),
     }
 }
 #[derive(Default)]
 struct ArithmeticAnalysis;
 
+#[derive(Debug, PartialEq, Eq, Clone)]
+enum ArithmeticAnalysisPayload {
+    Vol(u64),
+    Concentration(Concentration),
+    Fluid(Fluid),
+    None,
+}
+
+impl ArithmeticAnalysisPayload {
+    fn expect_vol(self) -> u64 {
+        match self {
+            ArithmeticAnalysisPayload::Vol(vol) => vol,
+            a => panic!("tried to get vol from payload, got {a:?}"),
+        }
+    }
+
+    fn expect_concentration(self) -> Concentration {
+        match self {
+            ArithmeticAnalysisPayload::Concentration(conc) => conc,
+            a => panic!("tried to get concentration from payload, got {a:?}"),
+        }
+    }
+
+    fn expect_fluid(self) -> Fluid {
+        match self {
+            ArithmeticAnalysisPayload::Fluid(fluid) => fluid,
+            a => panic!("tried to get fluid from payload, got {a:?}"),
+        }
+    }
+}
+
 impl Analysis<MixLang> for ArithmeticAnalysis {
-    type Data = Option<Concentration>;
+    type Data = ArithmeticAnalysisPayload;
 
     fn make(egraph: &EGraph<MixLang, Self>, enode: &MixLang) -> Self::Data {
         match enode {
-            MixLang::Mix(_) => None,
-            MixLang::Num(num) => Some(num.clone()),
-            MixLang::Add(add) => {
+            MixLang::Mix(_) => ArithmeticAnalysisPayload::None,
+            MixLang::Fluid(fluid) => {
+                let conc = fluid[0];
+                let vol = fluid[1];
+
+                let conc_node = &egraph[conc];
+                let vol_node = &egraph[vol];
+
+                let concentration = conc_node.data.clone().expect_concentration();
+                let vol = vol_node.data.clone().expect_vol();
+
+                let fluid = Fluid::new(concentration, vol);
+
+                ArithmeticAnalysisPayload::Fluid(fluid)
+            }
+            MixLang::ConcentrationAdd(add) => {
                 let node_a = add[0];
                 let node_b = add[1];
 
-                let node_a_num = egraph[node_a].data.as_ref();
-                let node_b_num = egraph[node_b].data.as_ref();
+                let node_a_fluid = egraph[node_a].data.clone().expect_fluid();
+                let node_b_fluid = egraph[node_b].data.clone().expect_fluid();
 
-                node_a_num
-                    .and_then(|node_a| node_b_num.map(|node_b| node_a.clone() + node_b.clone()))
+                let node_a_unit_vol = node_a_fluid.unit_volume();
+                let node_b_unit_vol = node_b_fluid.unit_volume();
+
+                // SAFETY: This is for sanity check, for `ConcentrationAdd` to be applied to any
+                // term during saturation, we require the volumes to be equal. So this should not
+                // fail. If it is failing, this is a critical bug.
+                assert_eq!(node_a_unit_vol, node_b_unit_vol);
+
+                let node_a_concentration = node_a_fluid.concentration();
+                let node_b_concentration = node_b_fluid.concentration();
+
+                let concentration = node_a_concentration.clone() + node_b_concentration.clone();
+                let new_fluid = Fluid::new(concentration, node_a_unit_vol);
+                ArithmeticAnalysisPayload::Fluid(new_fluid)
             }
-            MixLang::Sub(sub) => {
+            MixLang::ConcentrationSub(sub) => {
                 let node_a = sub[0];
                 let node_b = sub[1];
 
-                let node_a_num = egraph[node_a].data.as_ref();
-                let node_b_num = egraph[node_b].data.as_ref();
+                let node_a_fluid = egraph[node_a].data.clone().expect_fluid();
+                let node_b_fluid = egraph[node_b].data.clone().expect_fluid();
 
-                node_a_num
-                    .and_then(|node_a| node_b_num.map(|node_b| node_a.clone() - node_b.clone()))
+                let node_a_unit_vol = node_a_fluid.unit_volume();
+                let node_b_unit_vol = node_b_fluid.unit_volume();
+
+                // SAFETY: This is for sanity check, for `ConcentrationAdd` to be applied to any
+                // term during saturation, we require the volumes to be equal. So this should not
+                // fail. If it is failing, this is a critical bug.
+                assert_eq!(node_a_unit_vol, node_b_unit_vol);
+
+                let node_a_concentration = node_a_fluid.concentration();
+                let node_b_concentration = node_b_fluid.concentration();
+
+                let concentration = node_a_concentration.clone() - node_b_concentration.clone();
+                let new_fluid = Fluid::new(concentration, node_a_unit_vol);
+                ArithmeticAnalysisPayload::Fluid(new_fluid)
             }
+            MixLang::Vol(vol) => ArithmeticAnalysisPayload::Vol(*vol),
+            MixLang::Concentration(conc) => ArithmeticAnalysisPayload::Concentration(conc.clone()),
         }
     }
 
     fn merge(&mut self, to: &mut Self::Data, from: Self::Data) -> DidMerge {
-        merge_option(to, from, |a, b| {
+        let mut to = match to {
+            ArithmeticAnalysisPayload::None => None,
+            a => Some(a),
+        };
+        let mut binding = match from {
+            ArithmeticAnalysisPayload::None => None,
+            a => Some(a),
+        };
+        let from = binding.as_mut();
+
+        merge_option(&mut to, from, |a, b| {
             assert_eq!(*a, b, "Merged non-equal constants");
             DidMerge(false, false)
         })
     }
 
     fn modify(egraph: &mut EGraph<MixLang, Self>, id: Id) {
-        if let Some(data) = &egraph[id].data {
-            let added = egraph.add(MixLang::Num(data.clone()));
+        if let ArithmeticAnalysisPayload::Fluid(fl) = egraph[id].data.clone() {
+            let volume = fl.unit_volume();
+            let volume_node = egraph.add(MixLang::Vol(volume));
+
+            let concentration = fl.concentration();
+            let concentration_node = egraph.add(MixLang::Concentration(concentration.clone()));
+            let added = egraph.add(MixLang::Fluid([concentration_node, volume_node]));
             egraph.union(id, added);
         }
     }
@@ -60,29 +147,35 @@ impl Analysis<MixLang> for ArithmeticAnalysis {
 
 fn generate_mix_rules() -> Vec<Rewrite<MixLang, ArithmeticAnalysis>> {
     vec![
-        rw!("differentiate-mixer";
-            "(mix ?a ?b)" => "(mix (- ?a 0.001) (+ ?b 0.001))"),
-        rw!("differentiate-mixer2";
-            "(mix ?a ?b)" => "(mix (+ ?a 0.001) (- ?b 0.001))"),
-        rw!("expand-num";
-            "(?a)" => "(mix ?a ?a)"),
+        rw!("differentiate-mixer-conc1";
+            "(mix (fluid ?a ?c) (fluid ?b ?c))" => "(mix (c- (fluid ?a ?c) (fluid 0.001 ?c)) (c+ (fluid ?b ?c) (fluid 0.001 ?c)))"),
+        rw!("differentiate-mixer-conc2";
+            "(mix (fluid ?a ?c) (fluid ?b ?c))" => "(mix (c+ (fluid ?a ?c) (fluid 0.001 ?c)) (c- (fluid ?b ?c) (fluid 0.001 ?c)))"),
+        rw!("expand-fluid";
+            "(fluid ?a ?b)" => "(mix (fluid ?a ?b) (fluid ?a ?b))"),
     ]
 }
 
-struct SillyCostFn {
+struct SillyCostFn<'a> {
     input_space: HashSet<Concentration>,
     target: Concentration,
+    egraph: &'a EGraph<MixLang, ArithmeticAnalysis>,
 }
 
-impl SillyCostFn {
-    fn new(input_space: HashSet<Concentration>, target: Concentration) -> Self {
+impl<'a> SillyCostFn<'a> {
+    fn new(
+        input_space: HashSet<Concentration>,
+        target: Concentration,
+        egraph: &'a EGraph<MixLang, ArithmeticAnalysis>,
+    ) -> Self {
         Self {
             input_space,
             target,
+            egraph,
         }
     }
 }
-impl CostFunction<MixLang> for SillyCostFn {
+impl CostFunction<MixLang> for SillyCostFn<'_> {
     type Cost = f64;
 
     fn cost<C>(&mut self, enode: &MixLang, mut costs: C) -> Self::Cost
@@ -91,16 +184,21 @@ impl CostFunction<MixLang> for SillyCostFn {
     {
         let op_cost = match enode {
             MixLang::Mix(_) => 0.0,
-            MixLang::Num(num) => {
-                if *num == self.target {
+            MixLang::Fluid(fluid) => {
+                let concentration_id = fluid[0];
+                let concentration = self.egraph[concentration_id]
+                    .data
+                    .clone()
+                    .expect_concentration();
+                if concentration == self.target {
                     f64::MAX
-                } else if self.input_space.contains(num) {
+                } else if self.input_space.contains(&concentration) {
                     0.0
                 } else {
                     let closest_val = self
                         .input_space
                         .iter()
-                        .map(|input| (input.clone() - num.clone()).wrapped.abs())
+                        .map(|input| (input.clone() - concentration.clone()).wrapped.abs())
                         .min();
 
                     closest_val.unwrap() as f64
@@ -119,7 +217,7 @@ pub fn saturate(
     time_limit: u64,
     input_space: &[Concentration],
 ) -> Result<Sequence, MixerGenerationError> {
-    let start = format!("({})", target_concentration)
+    let start = format!("(fluid {} 1)", target_concentration)
         .parse()
         .map_err(|_| MixerGenerationError::FailedToParseTarget(target_concentration.clone()))?;
     let runner: Runner<MixLang, ArithmeticAnalysis, ()> = Runner::new(ArithmeticAnalysis)
@@ -135,7 +233,7 @@ pub fn saturate(
 
     let extractor = Extractor::new(
         &runner.egraph,
-        SillyCostFn::new(input_space, target_concentration),
+        SillyCostFn::new(input_space, target_concentration, &runner.egraph),
     );
 
     let (cost, best_expr) = extractor.find_best(runner.roots[0]);

--- a/fluido-ir/Cargo.toml
+++ b/fluido-ir/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 [dependencies]
 fluido-generation= { path = "../fluido-generation/" }
 fluido-types = { path = "../fluido-types/" }
-petgraph = "0.6.4"
+petgraph = { workspace = true }
 z3 = { version = "0.12", features = ["static-link-z3"] }
 
 [dev-dependencies]

--- a/fluido-ir/src/analysis/liveness.rs
+++ b/fluido-ir/src/analysis/liveness.rs
@@ -79,7 +79,7 @@ mod tests {
 
     #[test]
     fn single_mix_test() {
-        let mix_expr = "(mix 0.2 0.2)";
+        let mix_expr = "(mix (fluid 0.2 1) (fluid 0.2 1))";
         let ir = ir_from_str(mix_expr);
         let liveness_analysis = LivenessAnalysis {};
         let result = liveness_analysis.analyze(&ir);

--- a/fluido-ir/src/graph.rs
+++ b/fluido-ir/src/graph.rs
@@ -27,13 +27,13 @@ impl Graph {
         }
 
         match expr {
-            Expr::Number(_) => {}
             Expr::Mix(left, right) => {
                 let left_index = self.add_expr(left);
                 let right_index = self.add_expr(right);
                 self.graph.add_edge(index, left_index, ());
                 self.graph.add_edge(index, right_index, ());
             }
+            _ => {}
         }
         index
     }
@@ -56,7 +56,9 @@ impl Graph {
                     let _node = &self.graph[nr.0];
                     let node_label = match _node {
                         Expr::Mix(_, _) => "mix".to_string(),
-                        Expr::Number(con) => format!("{}", con),
+                        Expr::Fluid(fl) => format!("{}", fl),
+                        Expr::Vol(vol) => format!("{}", vol),
+                        Expr::Concentration(con) => format!("{}", con),
                     };
                     format!("label = {}", node_label)
                 },
@@ -80,8 +82,8 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_single_number() {
-        let expr_str = "0.5";
+    fn test_single_fluid() {
+        let expr_str = "(fluid 0.5 1)";
         let expr = Expr::parse(expr_str).unwrap();
         let graph_wrapper: Graph = (&expr).into();
 
@@ -91,7 +93,7 @@ mod tests {
 
     #[test]
     fn test_simple_mix() {
-        let expr_str = "(mix 0.1 0.2)";
+        let expr_str = "(mix (fluid 0.1 1) (fluid 0.2 1))";
         let expr = Expr::parse(expr_str).unwrap();
         let graph_wrapper: Graph = (&expr).into();
 
@@ -101,7 +103,7 @@ mod tests {
 
     #[test]
     fn test_nested_mix() {
-        let expr_str = "(mix(mix 0.0 0.2) 0.1)";
+        let expr_str = "(mix (mix (fluid 0.0 1) (fluid 0.2 1)) (fluid 0.1 1))";
         let expr = Expr::parse(expr_str).unwrap();
         let graph_wrapper: Graph = (&expr).into();
 

--- a/fluido-ir/src/graph.rs
+++ b/fluido-ir/src/graph.rs
@@ -26,14 +26,11 @@ impl Graph {
             self.root = Some(index);
         }
 
-        match expr {
-            Expr::Mix(left, right) => {
-                let left_index = self.add_expr(left);
-                let right_index = self.add_expr(right);
-                self.graph.add_edge(index, left_index, ());
-                self.graph.add_edge(index, right_index, ());
-            }
-            _ => {}
+        if let Expr::Mix(left, right) = expr {
+            let left_index = self.add_expr(left);
+            let right_index = self.add_expr(right);
+            self.graph.add_edge(index, left_index, ());
+            self.graph.add_edge(index, right_index, ());
         }
         index
     }

--- a/fluido-ir/src/ir.rs
+++ b/fluido-ir/src/ir.rs
@@ -1,4 +1,4 @@
-use fluido_types::concentration::Concentration;
+use fluido_types::fluid::Fluid;
 
 #[derive(Debug, Clone)]
 /// Possible IR operations for mixlang.
@@ -11,7 +11,7 @@ pub enum IROp {
 
 #[derive(Debug, Clone)]
 pub enum Operand {
-    Const(Concentration),
+    Const(Fluid),
     VirtualRegister(usize),
 }
 

--- a/fluido-parse/src/mixlang.pest
+++ b/fluido-parse/src/mixlang.pest
@@ -1,8 +1,17 @@
 // The entry point of the grammar, which tries to parse an expression
-expression = { mix | float }
+expression = { mix | fluid }
+
 // A rule to parse the mix operation, which contains two expressions
-mix = { "(" ~ "mix" ~ WS* ~ expression ~ WS+ ~ expression ~ ")" }
+mix = { "(" ~ "mix" ~ WS* ~ expression ~ WS+ ~ expression ~ WS* ~ ")" }
+
+// A rule to parse the fluid operation, which takes two parameters
+fluid = { "(" ~ "fluid" ~ WS+ ~ float ~ WS+ ~ integer ~ WS* ~ ")" }
+
 // A rule to parse floating point numbers
 float = { "-"? ~ ASCII_DIGIT+ ~ ("." ~ ASCII_DIGIT+)? }
+
+// A rule to parse integers
+integer = { "-"? ~ ASCII_DIGIT+ }
+
 // Whitespace handling
 WS = _{ " " | "\t" | "\n" | "\r" }

--- a/fluido-parse/src/parser.rs
+++ b/fluido-parse/src/parser.rs
@@ -1,4 +1,6 @@
-use fluido_types::{concentration::Concentration, error::IRGenerationError, expr::Expr};
+use fluido_types::{
+    concentration::Concentration, error::IRGenerationError, expr::Expr, fluid::Fluid,
+};
 use pest::Parser;
 use pest_derive::Parser;
 
@@ -35,7 +37,15 @@ fn build_ast(pairs: pest::iterators::Pairs<Rule>) -> Result<Expr, IRGenerationEr
         Rule::float => {
             let num = pair.as_str().parse::<f64>().unwrap();
             let concentration = Concentration::from(num);
-            Ok(Expr::Number(concentration))
+            Ok(Expr::Concentration(concentration))
+        }
+        Rule::integer => {
+            let num = pair.as_str().parse::<u64>().unwrap();
+            Ok(Expr::Vol(num))
+        }
+        Rule::fluid => {
+            let fluid = pair.as_str().parse::<Fluid>().unwrap();
+            Ok(Expr::Fluid(fluid))
         }
         _ => unreachable!(),
     }
@@ -43,39 +53,53 @@ fn build_ast(pairs: pest::iterators::Pairs<Rule>) -> Result<Expr, IRGenerationEr
 
 #[cfg(test)]
 mod tests {
-    use fluido_types::{concentration::Concentration, expr::Expr};
-
+    use fluido_types::{concentration::Concentration, expr::Expr, fluid::Fluid};
     use crate::parser::Parse;
 
     #[test]
-    fn pase_single_num() {
-        let input_str = "0.2";
+    fn parse_fluid() {
+        let input_str = "(fluid 0.2 1)";
         let expr = Expr::parse(input_str).unwrap();
-        let expected_expr = Expr::Number(Concentration::from(0.2));
-        assert_eq!(expected_expr, expr)
+        let expected_conc = Concentration::from(0.2);
+        let expected_vol = 1; 
+        let expected_fluid = Expr::Fluid(Fluid::new(expected_conc, expected_vol));
+        assert_eq!(expected_fluid, expr)
     }
 
     #[test]
-    fn pase_single_mix() {
-        let input_str = "(mix 0.2 0.3)";
+    fn parse_single_mix() {
+        let input_str = "(mix (fluid 0.2 1) (fluid 0.3 1))";
         let expr = Expr::parse(input_str).unwrap();
-        let zero_point_two = Expr::Number(Concentration::from(0.2));
-        let zero_point_three = Expr::Number(Concentration::from(0.3));
-        let expected_expr = Expr::Mix(Box::new(zero_point_two), Box::new(zero_point_three));
+        let unit_vol = 1u64;
+        
+        let zero_point_two = Concentration::from(0.2);
+        let zero_point_three = Concentration::from(0.3);
+        let first_fluid = Expr::Fluid(Fluid::new(zero_point_two, unit_vol));
+        let second_fluid = Expr::Fluid(Fluid::new(zero_point_three, unit_vol));
+        let expected_expr = Expr::Mix(Box::new(first_fluid), Box::new(second_fluid));
         assert_eq!(expected_expr, expr)
     }
 
     #[test]
     fn parse_nested_mix() {
-        let input_str = "(mix 0.2 (mix 0.3 0.4))";
+        let input_str = "(mix (fluid 0.2 1) (mix (fluid 0.3 1) (fluid 0.4 1)))";
         let expr = Expr::parse(input_str).unwrap();
-        let zero_point_three = Expr::Number(Concentration::from(0.3));
-        let zero_point_four = Expr::Number(Concentration::from(0.4));
+        let unit_vol = 1u64;
+        let zero_point_two = Concentration::from(0.2);
+        let zero_point_three = Concentration::from(0.3);
+        let zero_point_four = Concentration::from(0.4);
 
-        let first_mix = Expr::Mix(Box::new(zero_point_three), Box::new(zero_point_four));
-        let zero_point_two = Expr::Number(Concentration::from(0.2));
-        let expected_expr = Expr::Mix(Box::new(zero_point_two), Box::new(first_mix));
+        let first_fluid = Fluid::new(zero_point_two, unit_vol);
+        let second_fluid = Fluid::new(zero_point_three, unit_vol);
+        let third_fluid = Fluid::new(zero_point_four, unit_vol);
 
-        assert_eq!(expected_expr, expr)
+        let first_fluid_expr = Expr::Fluid(first_fluid);
+        let second_fluid_expr = Expr::Fluid(second_fluid);
+        let third_fluid_expr = Expr::Fluid(third_fluid);
+
+        let inner_mix = Expr::Mix(Box::new(second_fluid_expr), Box::new(third_fluid_expr));
+        let final_mix = Expr::Mix(Box::new(first_fluid_expr), Box::new(inner_mix));
+
+        assert_eq!(final_mix, expr)
     }
 }

--- a/fluido-parse/src/parser.rs
+++ b/fluido-parse/src/parser.rs
@@ -53,15 +53,15 @@ fn build_ast(pairs: pest::iterators::Pairs<Rule>) -> Result<Expr, IRGenerationEr
 
 #[cfg(test)]
 mod tests {
-    use fluido_types::{concentration::Concentration, expr::Expr, fluid::Fluid};
     use crate::parser::Parse;
+    use fluido_types::{concentration::Concentration, expr::Expr, fluid::Fluid};
 
     #[test]
     fn parse_fluid() {
         let input_str = "(fluid 0.2 1)";
         let expr = Expr::parse(input_str).unwrap();
         let expected_conc = Concentration::from(0.2);
-        let expected_vol = 1; 
+        let expected_vol = 1;
         let expected_fluid = Expr::Fluid(Fluid::new(expected_conc, expected_vol));
         assert_eq!(expected_fluid, expr)
     }
@@ -71,7 +71,7 @@ mod tests {
         let input_str = "(mix (fluid 0.2 1) (fluid 0.3 1))";
         let expr = Expr::parse(input_str).unwrap();
         let unit_vol = 1u64;
-        
+
         let zero_point_two = Concentration::from(0.2);
         let zero_point_three = Concentration::from(0.3);
         let first_fluid = Expr::Fluid(Fluid::new(zero_point_two, unit_vol));

--- a/fluido-types/Cargo.toml
+++ b/fluido-types/Cargo.toml
@@ -4,5 +4,5 @@ version = "0.0.0"
 edition = "2021"
 
 [dependencies]
-thiserror = { workspace = true } 
 egg = { workspace = true }
+thiserror = { workspace = true } 

--- a/fluido-types/Cargo.toml
+++ b/fluido-types/Cargo.toml
@@ -4,4 +4,5 @@ version = "0.0.0"
 edition = "2021"
 
 [dependencies]
-thiserror = "1.0.57"
+thiserror = { workspace = true } 
+egg = { workspace = true }

--- a/fluido-types/src/expr.rs
+++ b/fluido-types/src/expr.rs
@@ -1,7 +1,9 @@
-use crate::concentration::Concentration;
+use crate::{concentration::Concentration, fluid::Fluid};
 
 #[derive(Debug, PartialEq, Clone, Eq, Hash)]
 pub enum Expr {
     Mix(Box<Expr>, Box<Expr>),
-    Number(Concentration),
+    Concentration(Concentration),
+    Vol(u64),
+    Fluid(Fluid),
 }

--- a/fluido-types/src/fluid.rs
+++ b/fluido-types/src/fluid.rs
@@ -19,7 +19,7 @@ pub enum FluidParseError {
     MissingParanthesis,
     MissingFluidKeyword,
     MissingSpace,
-    MissingVolAndOrConcentration
+    MissingVolAndOrConcentration,
 }
 
 impl FromStr for Fluid {
@@ -31,8 +31,13 @@ impl FromStr for Fluid {
             s.remove(0);
             s.pop();
             let mut split_from_fluid_keyword = s.split("fluid");
-            let _= split_from_fluid_keyword.next().ok_or(FluidParseError::MissingFluidKeyword)?;
-            let s = split_from_fluid_keyword.next().ok_or(FluidParseError::MissingVolAndOrConcentration)?.trim();
+            let _ = split_from_fluid_keyword
+                .next()
+                .ok_or(FluidParseError::MissingFluidKeyword)?;
+            let s = split_from_fluid_keyword
+                .next()
+                .ok_or(FluidParseError::MissingVolAndOrConcentration)?
+                .trim();
             let mut splitted_s = s.split(' ');
             let concentration_str = splitted_s
                 .next()

--- a/fluido/Cargo.toml
+++ b/fluido/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.0.0"
 edition = "2021"
 
 [dependencies]
-anyhow = "1.0.79"
+anyhow = { workspace = true } 
 clap = { version = "4.5.0", features = ["derive"] }
 fluido-core = { path = "../fluido-core/" }
 fluido-types = { path = "../fluido-types/" }


### PR DESCRIPTION
This PR adds volume information to the representations used at the saturation step. Currently this volume info is not exploited for further optimized search but the result is still correct.

closes #27 