### PR TITLE
ci: silence clippy for empty docs until upstream improves

### DIFF
--- a/fluido-parse/src/parser.rs
+++ b/fluido-parse/src/parser.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::empty_docs)]
 use fluido_types::{
     concentration::Concentration, error::IRGenerationError, expr::Expr, fluid::Fluid,
 };


### PR DESCRIPTION
https://github.com/rust-lang/rust-clippy/issues/12377 -- upstream (the clippy itself) has a bug around empty docs and proc macros. Until the fix is released (it is merged) I am silencing the lint to unblock CI.