### PR TITLE
fix: remove unused update-output-files arg from e2e-tests

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,23 @@
+name: Coverage
+
+on: [pull_request, push]
+
+jobs:
+  coverage:
+    runs-on: ubuntu-latest
+    env:
+      CARGO_TERM_COLOR: always
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Rust
+        run: rustup update stable
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@cargo-llvm-cov
+      - name: Generate code coverage
+        run: cargo llvm-cov --all-features --workspace --lcov --output-path lcov.info
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v3
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: lcov.info
+          fail_ci_if_error: true

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,6 +1,9 @@
 name: Coverage
-
-on: [pull_request, push]
+'on':
+  push:
+    branches:
+      - master
+  pull_request: null
 
 jobs:
   coverage:

--- a/e2e-tests/src/cli.rs
+++ b/e2e-tests/src/cli.rs
@@ -15,10 +15,6 @@ pub struct Args {
     /// Print out warnings, errors, and output of print options
     #[arg(long, env = "FLUIDO_TEST_VERBOSE")]
     pub verbose: bool,
-
-    /// Update all output files
-    #[arg(long)]
-    pub update_output_files: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -30,5 +26,4 @@ pub struct FilterConfig {
 #[derive(Debug, Clone)]
 pub struct RunConfig {
     pub verbose: bool,
-    pub update_output_files: bool,
 }

--- a/e2e-tests/src/main.rs
+++ b/e2e-tests/src/main.rs
@@ -17,7 +17,6 @@ async fn main() -> anyhow::Result<()> {
     };
     let run_config = RunConfig {
         verbose: args.verbose,
-        update_output_files: args.update_output_files,
     };
 
     run(&run_config, &filter_config).await?;


### PR DESCRIPTION
Removes unused param from e2e-test binary, also update ci to run coverage on PRs once.