### PR TITLE
feat: make saturation generic over the number type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -426,9 +426,22 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "egg",
+ "fraction",
  "serde",
  "serde_test",
  "thiserror",
+]
+
+[[package]]
+name = "fraction"
+version = "0.15.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f158e3ff0a1b334408dc9fb811cd99b446986f4d8b741bb08f9df1604085ae7"
+dependencies = [
+ "lazy_static",
+ "num",
+ "serde",
+ "serde_derive",
 ]
 
 [[package]]
@@ -629,6 +642,82 @@ checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
+]
+
+[[package]]
+name = "num"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c165a9ab64cf766f73521c0dd2cfdff64f488b8f0b3e621face3462d3db536d7"
+dependencies = [
+ "num-integer",
+ "num-traits",
+ "serde",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "num-traits",
+ "serde",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+ "serde",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -148,6 +148,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bumpalo"
+version = "3.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
+
+[[package]]
 name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -266,6 +272,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-utils"
+version = "0.8.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
+
+[[package]]
 name = "crypto-common"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -305,15 +317,17 @@ dependencies = [
 [[package]]
 name = "egg"
 version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96beaf9d35dbc4686bc86a4ecb851fd6a406f0bf32d9f646b1225a5c5cf5b5d7"
+source = "git+https://github.com/kayagokalp/egg?branch=kayagokalp/generic-define-language#a1f9308f10e240df7cbbdfc865139ad672ec5bc0"
 dependencies = [
  "env_logger",
  "fxhash",
  "hashbrown 0.12.3",
  "indexmap 1.9.3",
- "instant",
  "log",
+ "num-bigint",
+ "num-traits",
+ "quanta",
+ "saturating",
  "smallvec",
  "symbol_table",
  "symbolic_expressions",
@@ -544,12 +558,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "instant"
-version = "0.1.12"
+name = "js-sys"
+version = "0.3.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
+checksum = "29c15563dc2726973df627357ce0c9ddddbea194836909d655df6a75d2cf296d"
 dependencies = [
- "cfg-if",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -845,12 +859,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "quanta"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5167a477619228a0b284fac2674e3c388cba90631d7b7de620e6f1fcd08da5"
+dependencies = [
+ "crossbeam-utils",
+ "libc",
+ "once_cell",
+ "raw-cpuid",
+ "wasi",
+ "web-sys",
+ "winapi",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "raw-cpuid"
+version = "11.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e29830cbb1290e404f24c73af91c5d8d631ce7e128691e9477556b540cd01ecd"
+dependencies = [
+ "bitflags",
 ]
 
 [[package]]
@@ -915,6 +953,12 @@ dependencies = [
  "linux-raw-sys",
  "windows-sys 0.52.0",
 ]
+
+[[package]]
+name = "saturating"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ece8e78b2f38ec51c51f5d475df0a7187ba5111b2a28bdc761ee05b075d40a71"
 
 [[package]]
 name = "scopeguard"
@@ -1175,6 +1219,70 @@ name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.92"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4be2531df63900aeb2bca0daaaddec08491ee64ceecbee5076636a3b026795a8"
+dependencies = [
+ "cfg-if",
+ "wasm-bindgen-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.92"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "614d787b966d3989fa7bb98a654e369c762374fd3213d212cfc0251257e747da"
+dependencies = [
+ "bumpalo",
+ "log",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.92"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1f8823de937b71b9460c0c34e25f3da88250760bec0ebac694b49997550d726"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.92"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.92"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96"
+
+[[package]]
+name = "web-sys"
+version = "0.3.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77afa9a11836342370f4817622a2f0f418b134426d91a82dfb48f532d2ec13ef"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "winapi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ members = ["fluido-generation", "fluido", "fluido-parse", "fluido-ir", "fluido-c
 [workspace.dependencies]
 anyhow = "1.0.79"
 clap = "4.5.0"
-egg = "0.9.5"
+egg = { git = "https://github.com/kayagokalp/egg", branch = "kayagokalp/generic-define-language" }
 petgraph = "0.6.4"
 thiserror = "1.0.57"
 serde = "1.0.202"

--- a/e2e-tests/src/harness.rs
+++ b/e2e-tests/src/harness.rs
@@ -1,7 +1,7 @@
 use std::str::FromStr;
 
 use fluido_core::{search_mixer_design, Config};
-use fluido_types::fluid::Fluid;
+use fluido_types::fluid::{Fluid, Number};
 
 use crate::{manifest::TestManifest, util::run_and_capture_output};
 
@@ -23,7 +23,7 @@ pub async fn run_saturation(
                 // Convert the error into anyhow error.
                 Fluid::from_str(&fluid_str).map_err(|err| err.into())
             })
-            .collect::<anyhow::Result<Vec<Fluid>>>()?;
+            .collect::<anyhow::Result<Vec<Fluid<Number>>>>()?;
         let target_fluids = setup
             .target
             .values()
@@ -35,11 +35,11 @@ pub async fn run_saturation(
                 // Convert the error into anyhow error.
                 Fluid::from_str(&fluid_str).map_err(|err| err.into())
             })
-            .collect::<anyhow::Result<Vec<Fluid>>>()?;
+            .collect::<anyhow::Result<Vec<Fluid<Number>>>>()?;
 
-        let target_concentration = target_fluids[0].concentration().clone();
+        let target_concentration: Number = target_fluids[0].concentration().clone();
         let mixer_design =
-            search_mixer_design(config, target_concentration, input_fluids.as_ref())?;
+            search_mixer_design::<Number>(config, target_concentration, input_fluids.as_ref())?;
 
         let mut result = true;
         if let Some(mixer_sequence) = &expected.mixer_sequence {

--- a/e2e-tests/src/harness.rs
+++ b/e2e-tests/src/harness.rs
@@ -37,7 +37,7 @@ pub async fn run_saturation(
             })
             .collect::<anyhow::Result<Vec<Fluid<Number>>>>()?;
 
-        let target_concentration: Number = target_fluids[0].concentration().clone();
+        let target_concentration: Number = *target_fluids[0].concentration();
         let mixer_design =
             search_mixer_design::<Number>(config, target_concentration, input_fluids.as_ref())?;
 

--- a/fluido-core/src/lib.rs
+++ b/fluido-core/src/lib.rs
@@ -13,7 +13,7 @@ use fluido_types::{
         FluidoError, IRGenerationError, InterefenceGraphGenerationError, MixerGenerationError,
     },
     expr::Expr,
-    fluid::{Concentration, Fluid, Number},
+    fluid::{Fluid, Number},
     number::SaturationNumber,
 };
 
@@ -114,12 +114,12 @@ impl MixerGenerationConfig {
 }
 
 /// Generate a mixer for the target_concentration from input space.
-fn generate_mixer_sequence(
-    target_concentration: Concentration,
-    input_space: &[Fluid<Number>],
+fn generate_mixer_sequence<T: SaturationNumber + 'static>(
+    target_concentration: T,
+    input_space: &[Fluid<T>],
     time_limit: u64,
     mixer_generator: MixerGenerator,
-) -> Result<Sequence, MixerGenerationError> {
+) -> Result<Sequence<T>, MixerGenerationError> {
     match mixer_generator {
         MixerGenerator::EqualitySaturation => {
             let generated_mixer_sequence =
@@ -130,7 +130,9 @@ fn generate_mixer_sequence(
 }
 
 /// Generates a `mixer-graph` from expr.
-fn generate_graph<T: SaturationNumber>(sequence: Sequence) -> Result<Graph<T>, IRGenerationError> {
+fn generate_graph<T: SaturationNumber>(
+    sequence: Sequence<T>,
+) -> Result<Graph<T>, IRGenerationError> {
     let best_expr = sequence.best_expr;
     let expr_str = format!("{best_expr}");
     let expr = Expr::parse(&expr_str)?;

--- a/fluido-ir/src/analysis/liveness.rs
+++ b/fluido-ir/src/analysis/liveness.rs
@@ -1,5 +1,7 @@
 use std::collections::HashSet;
 
+use fluido_types::number::SaturationNumber;
+
 use crate::{
     ir::{IROp, Operand},
     pass_manager::{AnalysisPass, AnalysisResult},
@@ -8,8 +10,8 @@ use crate::{
 #[derive(Default)]
 pub struct LivenessAnalysis {}
 
-impl AnalysisPass for LivenessAnalysis {
-    fn analyze(&self, ir_to_pass_over: &[IROp]) -> crate::pass_manager::AnalysisResult {
+impl<T: SaturationNumber> AnalysisPass<T> for LivenessAnalysis {
+    fn analyze(&self, ir_to_pass_over: &[IROp<T>]) -> crate::pass_manager::AnalysisResult {
         let mut live_regs = vec![];
         let mut ir = ir_to_pass_over.to_vec();
         ir.reverse();
@@ -67,10 +69,10 @@ mod tests {
     use super::LivenessAnalysis;
     use crate::{graph::Graph, ir::IROp, ir_builder::IRBuilder, pass_manager::AnalysisPass};
     use fluido_parse::parser::Parse;
-    use fluido_types::expr::Expr;
+    use fluido_types::{expr::Expr, fluid::LimitedFloat, number::SaturationNumber};
     use std::collections::HashSet;
 
-    fn ir_from_str(input_str: &str) -> Vec<IROp> {
+    fn ir_from_str<T: SaturationNumber>(input_str: &str) -> Vec<IROp<T>> {
         let mix_expr_parsed = Expr::parse(input_str).unwrap();
         let mixer_graph = Graph::from(&mix_expr_parsed);
         let mut ir_builder = IRBuilder::default();
@@ -78,9 +80,9 @@ mod tests {
     }
 
     #[test]
-    fn single_mix_test() {
+    fn single_mix_test_lf() {
         let mix_expr = "(mix (fluid 0.2 1) (fluid 0.2 1))";
-        let ir = ir_from_str(mix_expr);
+        let ir: Vec<IROp<LimitedFloat>> = ir_from_str(mix_expr);
         let liveness_analysis = LivenessAnalysis {};
         let result = liveness_analysis.analyze(&ir);
 

--- a/fluido-ir/src/graph.rs
+++ b/fluido-ir/src/graph.rs
@@ -54,7 +54,7 @@ impl Graph {
                     let node_label = match _node {
                         Expr::Mix(_, _) => "mix".to_string(),
                         Expr::Fluid(fl) => format!("{}", fl),
-                        Expr::LimitedFloat(fl) => format!("{}", fl),
+                        Expr::Number(nm) => format!("{}", nm),
                     };
                     format!("label = {}", node_label)
                 },

--- a/fluido-ir/src/ir.rs
+++ b/fluido-ir/src/ir.rs
@@ -1,21 +1,21 @@
-use fluido_types::fluid::Fluid;
+use fluido_types::{fluid::Fluid, number::SaturationNumber};
 
 #[derive(Debug, Clone)]
 /// Possible IR operations for mixlang.
-pub enum IROp {
+pub enum IROp<T: SaturationNumber> {
     // store value_to_store v_register_destination
-    Store((Operand, Operand)),
+    Store((Operand<T>, Operand<T>)),
     // mix in1_vreg in2_vreg, target_vreg
-    Mix((Operand, Operand, Operand)),
+    Mix((Operand<T>, Operand<T>, Operand<T>)),
 }
 
 #[derive(Debug, Clone)]
-pub enum Operand {
-    Const(Fluid),
+pub enum Operand<T: SaturationNumber> {
+    Const(Fluid<T>),
     VirtualRegister(usize),
 }
 
-impl std::fmt::Display for IROp {
+impl<T: SaturationNumber> std::fmt::Display for IROp<T> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             IROp::Store(store) => write!(f, "store {} {}", store.0, store.1),
@@ -24,7 +24,7 @@ impl std::fmt::Display for IROp {
     }
 }
 
-impl std::fmt::Display for Operand {
+impl<T: SaturationNumber> std::fmt::Display for Operand<T> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Operand::Const(num) => write!(f, "{}", num),
@@ -36,31 +36,61 @@ impl std::fmt::Display for Operand {
 #[cfg(test)]
 mod tests {
     use crate::ir::{IROp, Operand};
-    use fluido_types::fluid::{Concentration, Fluid, Volume};
+    use fluido_types::fluid::{Fluid, Frac, LimitedFloat};
 
-    fn get_dummy_fluid() -> Fluid {
-        let concentration_a = Concentration::from(0.1);
-        let voluma_a = Volume::from(1.0);
+    fn get_dummy_fluid_lf() -> Fluid<LimitedFloat> {
+        let concentration_a = LimitedFloat::from(0.1);
+        let voluma_a = LimitedFloat::from(1.0);
         Fluid::new(concentration_a, voluma_a)
     }
     #[test]
-    fn test_operand_display() {
-        let const_op = Operand::Const(get_dummy_fluid());
+    fn test_operand_display_lf() {
+        let const_op = Operand::Const(get_dummy_fluid_lf());
         assert_eq!(format!("{}", const_op), "(fluid 0.1 1.0)");
 
-        let vreg_op = Operand::VirtualRegister(42);
+        let vreg_op: Operand<LimitedFloat> = Operand::VirtualRegister(42);
         assert_eq!(format!("{}", vreg_op), "%42");
     }
 
     #[test]
-    fn test_irops_display() {
+    fn test_irops_display_lf() {
         let store_op = IROp::Store((
-            Operand::Const(get_dummy_fluid()),
+            Operand::Const(get_dummy_fluid_lf()),
             Operand::VirtualRegister(1),
         ));
         assert_eq!(format!("{}", store_op), "store (fluid 0.1 1.0) %1");
 
-        let mix_op = IROp::Mix((
+        let mix_op: IROp<LimitedFloat> = IROp::Mix((
+            Operand::VirtualRegister(1),
+            Operand::VirtualRegister(2),
+            Operand::VirtualRegister(3),
+        ));
+        assert_eq!(format!("{}", mix_op), "mix %1 %2 %3");
+    }
+
+    fn get_dummy_fluid_frac() -> Fluid<Frac> {
+        let concentration_a = Frac::from(0.1);
+        let voluma_a = Frac::from(1.0);
+        Fluid::new(concentration_a, voluma_a)
+    }
+    #[test]
+    fn test_operand_display_frac() {
+        let const_op = Operand::Const(get_dummy_fluid_frac());
+        assert_eq!(format!("{}", const_op), "(fluid 1/10 1)");
+
+        let vreg_op: Operand<Frac> = Operand::VirtualRegister(42);
+        assert_eq!(format!("{}", vreg_op), "%42");
+    }
+
+    #[test]
+    fn test_irops_display_frac() {
+        let store_op = IROp::Store((
+            Operand::Const(get_dummy_fluid_frac()),
+            Operand::VirtualRegister(1),
+        ));
+        assert_eq!(format!("{}", store_op), "store (fluid 1/10 1) %1");
+
+        let mix_op: IROp<Frac> = IROp::Mix((
             Operand::VirtualRegister(1),
             Operand::VirtualRegister(2),
             Operand::VirtualRegister(3),

--- a/fluido-parse/src/mixlang.pest
+++ b/fluido-parse/src/mixlang.pest
@@ -7,8 +7,14 @@ mix = { "(" ~ "mix" ~ WS* ~ expression ~ WS+ ~ expression ~ WS* ~ ")" }
 // A rule to parse the fluid operation, which takes two parameters
 fluid = { "(" ~ "fluid" ~ WS+ ~ float ~ WS+ ~ float ~ WS* ~ ")" }
 
-// A rule to parse floating point numbers
-float = { "-"? ~ ASCII_DIGIT+ ~ ("." ~ ASCII_DIGIT+)? }
+// A rule to parse floating point numbers and fractions
+float = _{ fraction | number }
+
+// A rule to parse fractions in the form of "1/10"
+fraction = { ASCII_DIGIT+ ~ "/" ~ ASCII_DIGIT+ }
+
+// A rule to parse floating point numbers in the form of "0.1"
+number = { "-"? ~ ASCII_DIGIT+ ~ ("." ~ ASCII_DIGIT+)? }
 
 // Whitespace handling
 WS = _{ " " | "\t" | "\n" | "\r" }

--- a/fluido-parse/src/parser.rs
+++ b/fluido-parse/src/parser.rs
@@ -2,7 +2,7 @@
 use fluido_types::{
     error::IRGenerationError,
     expr::Expr,
-    fluid::{Fluid, LimitedFloat},
+    fluid::{Fluid, Number},
 };
 use pest::Parser;
 use pest_derive::Parser;
@@ -43,8 +43,8 @@ fn build_ast(pairs: pest::iterators::Pairs<Rule>) -> Result<Expr, IRGenerationEr
         }
         Rule::float => {
             let num = pair.as_str().parse::<f64>().unwrap();
-            let concentration = LimitedFloat::from(num);
-            Ok(Expr::LimitedFloat(concentration))
+            let concentration = Number::from(num);
+            Ok(Expr::Number(concentration))
         }
         Rule::fluid => {
             let fluid = pair.as_str().parse::<Fluid>().unwrap();

--- a/fluido-parse/src/parser.rs
+++ b/fluido-parse/src/parser.rs
@@ -59,9 +59,22 @@ mod tests {
         expr::Expr,
         fluid::{Concentration, Fluid, Volume},
     };
+    #[test]
+    fn parse_single_mix_frac() {
+        let input_str = "(mix (fluid 0.2 1.0) (fluid 0.3 1.0))";
+        let expr = Expr::parse(input_str).unwrap();
+        let unit_vol = Volume::from(1.0);
+
+        let zero_point_two = Concentration::from(0.2);
+        let zero_point_three = Concentration::from(0.3);
+        let first_fluid = Expr::Fluid(Fluid::new(zero_point_two, unit_vol.clone()));
+        let second_fluid = Expr::Fluid(Fluid::new(zero_point_three, unit_vol));
+        let expected_expr = Expr::Mix(Box::new(first_fluid), Box::new(second_fluid));
+        assert_eq!(expected_expr, expr)
+    }
 
     #[test]
-    fn parse_single_mix() {
+    fn parse_single_mix_lf() {
         let input_str = "(mix (fluid 0.2 1.0) (fluid 0.3 1.0))";
         let expr = Expr::parse(input_str).unwrap();
         let unit_vol = Volume::from(1.0);

--- a/fluido-types/Cargo.toml
+++ b/fluido-types/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 [dependencies]
 anyhow = { workspace = true }
 egg = { workspace = true }
+fraction = { version = "0.15.3", features = ["with-serde-support"] }
 serde = { workspace = true, features = ["derive"] }
 thiserror = { workspace = true } 
 

--- a/fluido-types/src/error.rs
+++ b/fluido-types/src/error.rs
@@ -1,4 +1,3 @@
-use crate::fluid::Concentration;
 use thiserror::Error;
 
 #[derive(Error, Debug)]
@@ -6,7 +5,7 @@ pub enum MixerGenerationError {
     #[error("Saturation error while generating the mixer space: {0}")]
     SaturationError(String),
     #[error("Failed to parse target concentration (`{0}`) as a node.")]
-    FailedToParseTarget(Concentration),
+    FailedToParseTarget(String),
 }
 
 #[derive(Error, Debug)]

--- a/fluido-types/src/expr.rs
+++ b/fluido-types/src/expr.rs
@@ -1,8 +1,8 @@
-use crate::fluid::{Fluid, Number};
+use crate::{fluid::Fluid, number::SaturationNumber};
 
 #[derive(Debug, PartialEq, Clone, Eq, Hash)]
-pub enum Expr {
-    Mix(Box<Expr>, Box<Expr>),
-    Number(Number),
-    Fluid(Fluid<Number>),
+pub enum Expr<T: SaturationNumber> {
+    Mix(Box<Expr<T>>, Box<Expr<T>>),
+    Number(T),
+    Fluid(Fluid<T>),
 }

--- a/fluido-types/src/expr.rs
+++ b/fluido-types/src/expr.rs
@@ -1,8 +1,8 @@
-use crate::fluid::{Concentration, Fluid};
+use crate::fluid::{Fluid, Number};
 
 #[derive(Debug, PartialEq, Clone, Eq, Hash)]
 pub enum Expr {
     Mix(Box<Expr>, Box<Expr>),
-    LimitedFloat(Concentration),
-    Fluid(Fluid),
+    Number(Number),
+    Fluid(Fluid<Number>),
 }

--- a/fluido-types/src/fluid.rs
+++ b/fluido-types/src/fluid.rs
@@ -1,19 +1,26 @@
-use std::{fmt::Display, num::ParseFloatError, str::FromStr};
+use std::{
+    fmt::Display,
+    ops::{Add, Div, Mul},
+    str::FromStr,
+};
 
-pub use crate::number::LimitedFloat;
-pub type Concentration = LimitedFloat;
-pub type Volume = LimitedFloat;
+use crate::number::SaturationNumber;
+pub use crate::number::{Frac, LimitedFloat};
+
+pub type Number = Frac;
+pub type Concentration = Frac;
+pub type Volume = Frac;
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
-pub struct Fluid {
-    concentration: Concentration,
-    unit_volume: Volume,
+pub struct Fluid<T: SaturationNumber> {
+    concentration: T,
+    unit_volume: T,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum FluidParseError {
-    InvalidFloatParse(ParseFloatError),
-    InvalidVolumeParse(ParseFloatError),
+    InvalidFloatParse(String),
+    InvalidVolumeParse(String),
     MissingParanthesis,
     MissingFluidKeyword,
     MissingSpace,
@@ -26,7 +33,7 @@ impl From<FluidParseError> for anyhow::Error {
     }
 }
 
-impl FromStr for Fluid {
+impl<T: SaturationNumber> FromStr for Fluid<T> {
     type Err = FluidParseError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
@@ -52,10 +59,10 @@ impl FromStr for Fluid {
                 .ok_or(FluidParseError::MissingSpace)?
                 .trim();
 
-            let concentration = Concentration::from_str(concentration_str)
-                .map_err(FluidParseError::InvalidFloatParse)?;
-            let unit_volume =
-                Volume::from_str(unit_volume_str).map_err(FluidParseError::InvalidVolumeParse)?;
+            let concentration = T::parse(concentration_str)
+                .map_err(|e| FluidParseError::InvalidFloatParse(e.to_string()))?;
+            let unit_volume = T::parse(unit_volume_str)
+                .map_err(|e| FluidParseError::InvalidVolumeParse(e.to_string()))?;
 
             let fluid = Self {
                 concentration,
@@ -68,7 +75,7 @@ impl FromStr for Fluid {
     }
 }
 
-impl Display for Fluid {
+impl<T: SaturationNumber> Display for Fluid<T> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "(")?;
         write!(f, "fluid")?;
@@ -80,45 +87,47 @@ impl Display for Fluid {
     }
 }
 
-impl Fluid {
+// TODO: Make fluid generic over number type.
+impl<T: SaturationNumber + Mul<Output = T> + Add<Output = T> + Div<Output = T>> Fluid<T> {
     /// Creates a new fluid.
     ///
     /// Note: Assumes the volume is non-zero.
-    pub fn new(concentration: Concentration, unit_volume: Volume) -> Self {
+    pub fn new(concentration: T, unit_volume: T) -> Self {
         Self {
             concentration,
             unit_volume,
         }
     }
 
-    /// Mix two fluids, this is a high level representation so it assumes:
+    /// Mix two fluids, it assumes:
     ///  1. Fluids mixes perfectly
     ///  2. Input fluids volumes summed equals to output fluid. (No loss in terms of liquid
     ///     volume).
-    pub fn mix(&self, other: &Fluid) -> Self {
-        let self_conc: f64 = self.concentration.clone().into();
-        let other_conc: f64 = other.concentration.clone().into();
+    pub fn mix(&self, other: &Fluid<T>) -> Self {
+        let self_conc = self.concentration.clone();
+        let other_conc = other.concentration.clone();
 
-        let self_vol: f64 = self.unit_volume().clone().into();
-        let other_vol: f64 = other.unit_volume().clone().into();
+        let self_vol = self.unit_volume().clone();
+        let other_vol = other.unit_volume().clone();
 
-        let resulting_vol = self_vol + other_vol;
+        let resulting_vol = self_vol.clone() + other_vol.clone();
 
-        let resulting_conc = ((self_conc * self_vol) + (other_conc * other_vol)) / resulting_vol;
-
-        let resulting_conc = Concentration::from(resulting_conc);
-        let resulting_vol = Volume::from(resulting_vol);
+        dbg!(self_conc.clone());
+        dbg!(self_vol.clone());
+        let self_mult: T = self_conc * self_vol;
+        let other_mult: T = other_conc * other_vol;
+        let resulting_conc = (self_mult + other_mult) / resulting_vol.clone();
 
         Self::new(resulting_conc, resulting_vol)
     }
 
     /// Returns a reference to the underlying `Concentration` for this fluid.
-    pub fn concentration(&self) -> &Concentration {
+    pub fn concentration(&self) -> &T {
         &self.concentration
     }
 
     /// Returns a reference to the underlying unit_volume.
-    pub fn unit_volume(&self) -> &Volume {
+    pub fn unit_volume(&self) -> &T {
         &self.unit_volume
     }
 }
@@ -149,17 +158,54 @@ mod tests {
 
     #[test]
     fn mix_two_diff_volumed_fluids() {
-        let concentration_a = Concentration::from(0.04);
-        let voluma_a = Volume::from(1.0);
+        let concentration_a = Frac::from(0.04);
+        let voluma_a = Frac::from(1.0);
         let fluid_a = Fluid::new(concentration_a, voluma_a);
 
-        let concentration_b = Concentration::from(0.0);
-        let voluma_b = Volume::from(3.0);
+        let concentration_b = Frac::from(0.0);
+        let voluma_b = Frac::from(3.0);
         let fluid_b = Fluid::new(concentration_b, voluma_b);
 
         let resulting_fluid = fluid_a.mix(&fluid_b);
-        let expected_concentration = Concentration::from(0.01);
-        let expected_volume = Volume::from(4.0);
+        let expected_concentration = Frac::from(0.01);
+        let expected_volume = Frac::from(4.0);
+        let expected_fluid = Fluid::new(expected_concentration, expected_volume);
+
+        assert_eq!(expected_fluid, resulting_fluid);
+    }
+
+    #[test]
+    fn mix_two_equal_volume_fluids_limited_float() {
+        let concentration_a = LimitedFloat::from(0.1);
+        let voluma_a = LimitedFloat::from(1.0);
+        let fluid_a = Fluid::new(concentration_a, voluma_a);
+
+        let concentration_b = LimitedFloat::from(0.2);
+        let voluma_b = LimitedFloat::from(1.0);
+        let fluid_b = Fluid::new(concentration_b, voluma_b);
+
+        let resulting_fluid = fluid_a.mix(&fluid_b);
+
+        let expected_concentration = LimitedFloat::from(0.15);
+        let expected_volume = LimitedFloat::from(2.0);
+        let expected_fluid = Fluid::new(expected_concentration, expected_volume);
+
+        assert_eq!(expected_fluid, resulting_fluid);
+    }
+
+    #[test]
+    fn mix_two_diff_volumed_fluids_limited_float() {
+        let concentration_a = LimitedFloat::from(0.04);
+        let voluma_a = LimitedFloat::from(1.0);
+        let fluid_a = Fluid::new(concentration_a, voluma_a);
+
+        let concentration_b = LimitedFloat::from(0.0);
+        let voluma_b = LimitedFloat::from(3.0);
+        let fluid_b = Fluid::new(concentration_b, voluma_b);
+
+        let resulting_fluid = fluid_a.mix(&fluid_b);
+        let expected_concentration = LimitedFloat::from(0.01);
+        let expected_volume = LimitedFloat::from(4.0);
         let expected_fluid = Fluid::new(expected_concentration, expected_volume);
 
         assert_eq!(expected_fluid, resulting_fluid);
@@ -167,7 +213,7 @@ mod tests {
 
     #[test]
     fn parse_fluid_str() {
-        let parsed_fluid = Fluid::from_str("(fluid 0.1 1.0)").unwrap();
+        let parsed_fluid: Fluid<LimitedFloat> = Fluid::from_str("(fluid 0.1 1.0)").unwrap();
         let expected_fluid = Fluid::new(0.1.into(), 1.0.into());
 
         assert_eq!(expected_fluid, parsed_fluid)

--- a/fluido-types/src/fluid.rs
+++ b/fluido-types/src/fluid.rs
@@ -1,15 +1,11 @@
-use std::{
-    fmt::Display,
-    ops::{Add, Div, Mul},
-    str::FromStr,
-};
+use std::{fmt::Display, str::FromStr};
 
 use crate::number::SaturationNumber;
 pub use crate::number::{Frac, LimitedFloat};
 
 pub type Number = Frac;
-pub type Concentration = Frac;
-pub type Volume = Frac;
+pub type Concentration = Number;
+pub type Volume = Number;
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct Fluid<T: SaturationNumber> {
@@ -88,7 +84,7 @@ impl<T: SaturationNumber> Display for Fluid<T> {
 }
 
 // TODO: Make fluid generic over number type.
-impl<T: SaturationNumber + Mul<Output = T> + Add<Output = T> + Div<Output = T>> Fluid<T> {
+impl<T: SaturationNumber> Fluid<T> {
     /// Creates a new fluid.
     ///
     /// Note: Assumes the volume is non-zero.

--- a/fluido-types/src/fluid.rs
+++ b/fluido-types/src/fluid.rs
@@ -100,19 +100,19 @@ impl<T: SaturationNumber> Fluid<T> {
     ///  2. Input fluids volumes summed equals to output fluid. (No loss in terms of liquid
     ///     volume).
     pub fn mix(&self, other: &Fluid<T>) -> Self {
-        let self_conc = self.concentration.clone();
-        let other_conc = other.concentration.clone();
+        let self_conc = self.concentration;
+        let other_conc = other.concentration;
 
-        let self_vol = self.unit_volume().clone();
-        let other_vol = other.unit_volume().clone();
+        let self_vol = *self.unit_volume();
+        let other_vol = *other.unit_volume();
 
-        let resulting_vol = self_vol.clone() + other_vol.clone();
+        let resulting_vol = self_vol + other_vol;
 
-        dbg!(self_conc.clone());
-        dbg!(self_vol.clone());
+        dbg!(self_conc);
+        dbg!(self_vol);
         let self_mult: T = self_conc * self_vol;
         let other_mult: T = other_conc * other_vol;
-        let resulting_conc = (self_mult + other_mult) / resulting_vol.clone();
+        let resulting_conc = (self_mult + other_mult) / resulting_vol;
 
         Self::new(resulting_conc, resulting_vol)
     }

--- a/fluido-types/src/number.rs
+++ b/fluido-types/src/number.rs
@@ -44,7 +44,7 @@ pub struct Frac {
 impl SaturationNumber for Frac {
     fn valid(&self) -> bool {
         let f64_val: f64 = self.into();
-        f64_val >= 0.0 && f64_val < 1.0
+        (0.0..1.0).contains(&f64_val)
     }
 
     fn parse(str: &str) -> anyhow::Result<Self> {
@@ -104,20 +104,9 @@ impl Display for Frac {
     }
 }
 
-/// Blanket implementation for f64 <-> Frac conversion.
-impl<T> From<&T> for Frac
-where
-    T: Into<Frac>,
-{
-    fn from(value: &T) -> Self {
-        // TODO: consider making Frac a copy type.
-        value.into()
-    }
-}
-
 impl From<&Frac> for f64 {
     fn from(value: &Frac) -> Self {
-        let val = value.clone();
+        let val = *value;
         val.into()
     }
 }

--- a/fluido-types/src/number.rs
+++ b/fluido-types/src/number.rs
@@ -9,6 +9,7 @@ use std::{
 
 pub trait SaturationNumber:
     Clone
+    + Copy
     + From<f64>
     + Into<f64>
     + Display
@@ -22,12 +23,15 @@ pub trait SaturationNumber:
     + Eq
     + Ord
     + PartialOrd
+    + Send
+    + Sync
+    + FromStr<Err = anyhow::Error>
 {
     fn valid(&self) -> bool;
     fn parse(str: &str) -> anyhow::Result<Self>;
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
 pub struct LimitedFloat {
     pub wrapped: i64,
 }

--- a/fluido-types/src/number.rs
+++ b/fluido-types/src/number.rs
@@ -1,25 +1,36 @@
+use fraction::Fraction;
 use serde::{Deserialize, Serialize};
 use std::{
-    cmp::max,
-    num::ParseFloatError,
+    fmt::{Debug, Display},
     ops::{Add, Div, Mul, Sub},
     str::FromStr,
 };
+
+pub trait SaturationNumber:
+    Clone + From<f64> + Into<f64> + Display + Add + Sub + Mul + Div + Debug
+{
+    fn valid(&self) -> bool;
+    fn parse(str: &str) -> anyhow::Result<Self>;
+}
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
 pub struct LimitedFloat {
     pub wrapped: i64,
 }
 
-#[derive(Debug, PartialEq, Eq, Clone, Copy, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy, Serialize, Deserialize, PartialOrd, Ord, Hash)]
 pub struct Frac {
-    numerator: i32,
-    power: i32,
+    fraction: Fraction,
 }
 
-impl Frac {
-    fn new(numerator: i32, power: i32) -> Self {
-        Self { numerator, power }
+impl SaturationNumber for Frac {
+    fn valid(&self) -> bool {
+        let f64_val: f64 = self.into();
+        f64_val >= 0.0 && f64_val < 1.0
+    }
+
+    fn parse(str: &str) -> anyhow::Result<Self> {
+        Self::from_str(str)
     }
 }
 
@@ -27,16 +38,8 @@ impl Add for Frac {
     type Output = Self;
 
     fn add(self, other: Self) -> Self {
-        if self.power == other.power {
-            // If powers are equal, simply add the numerators
-            Self::new(self.numerator + other.numerator, self.power)
-        } else {
-            // If powers are different, align them to the common power
-            let common_power = max(self.power, other.power);
-            let numerator1 = self.numerator << (common_power - self.power);
-            let numerator2 = other.numerator << (common_power - other.power);
-            Self::new(numerator1 + numerator2, common_power)
-        }
+        let new_frac = self.fraction + other.fraction;
+        Self { fraction: new_frac }
     }
 }
 
@@ -44,16 +47,8 @@ impl Sub for Frac {
     type Output = Self;
 
     fn sub(self, other: Self) -> Self {
-        if self.power == other.power {
-            // If powers are equal, simply subtract the numerators
-            Self::new(self.numerator - other.numerator, self.power)
-        } else {
-            // If powers are different, align them to the common power
-            let common_power = max(self.power, other.power);
-            let numerator1 = self.numerator << (common_power - self.power);
-            let numerator2 = other.numerator << (common_power - other.power);
-            Self::new(numerator1 - numerator2, common_power)
-        }
+        let new_frac = self.fraction - other.fraction;
+        Self { fraction: new_frac }
     }
 }
 
@@ -62,7 +57,8 @@ impl Mul for Frac {
 
     fn mul(self, other: Self) -> Self {
         // Multiply the numerators and add the powers
-        Self::new(self.numerator * other.numerator, self.power + other.power)
+        let new_frac = self.fraction * other.fraction;
+        Self { fraction: new_frac }
     }
 }
 
@@ -71,15 +67,72 @@ impl Div for Frac {
 
     fn div(self, other: Self) -> Self {
         // Divide the numerators and subtract the powers
-        Self::new(self.numerator / other.numerator, self.power - other.power)
+        let new_frac = self.fraction / other.fraction;
+        Self { fraction: new_frac }
+    }
+}
+
+// TODO: differentiate this from LimitedFloat.
+impl FromStr for Frac {
+    type Err = anyhow::Error;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let lf = LimitedFloat::from_str(s)?;
+        let f64_val: f64 = lf.into();
+        Ok(Self::from(f64_val))
+    }
+}
+
+// TODO: differentiate this from LimitedFloat.
+impl Display for Frac {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let f64_val: f64 = self.into();
+        let lf = LimitedFloat::from(f64_val);
+        write!(f, "{}", lf)
+    }
+}
+
+/// Blanket implementation for f64 <-> Frac conversion.
+impl<T> From<&T> for Frac
+where
+    T: Into<Frac>,
+{
+    fn from(value: &T) -> Self {
+        // TODO: consider making Frac a copy type.
+        value.into()
+    }
+}
+
+impl From<&Frac> for f64 {
+    fn from(value: &Frac) -> Self {
+        let val = value.clone();
+        val.into()
+    }
+}
+
+impl From<f64> for Frac {
+    fn from(value: f64) -> Self {
+        let fraction = Fraction::from(value);
+        Self { fraction }
+    }
+}
+
+impl From<Frac> for f64 {
+    fn from(value: Frac) -> Self {
+        value.fraction.try_into().unwrap()
+    }
+}
+
+impl SaturationNumber for LimitedFloat {
+    fn valid(&self) -> bool {
+        self.wrapped >= 0 && self.wrapped as f64 <= 1.0f64 / Self::EPSILON
+    }
+
+    fn parse(str: &str) -> anyhow::Result<Self> {
+        Self::from_str(str)
     }
 }
 
 impl LimitedFloat {
-    pub fn valid(&self) -> bool {
-        self.wrapped >= 0 && self.wrapped as f64 <= 1.0f64 / Self::EPSILON
-    }
-
     pub const EPSILON: f64 = 0.0001;
 }
 
@@ -148,7 +201,7 @@ impl From<f64> for LimitedFloat {
 }
 
 impl FromStr for LimitedFloat {
-    type Err = ParseFloatError;
+    type Err = anyhow::Error;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let f64_val = s.parse::<f64>()?;
@@ -176,11 +229,18 @@ impl std::fmt::Display for LimitedFloat {
 
 #[cfg(test)]
 mod tests {
+    use super::LimitedFloat;
+    use crate::number::{Frac, SaturationNumber};
+    use fraction::Fraction;
     use serde_test::{assert_tokens, Token};
 
-    use crate::number::Frac;
-
-    use super::LimitedFloat;
+    /// Frac::new impl for easy testing.
+    impl Frac {
+        fn new(num1: u16, num2: u16) -> Self {
+            let fraction = Fraction::new(num1, num2);
+            Self { fraction }
+        }
+    }
 
     #[test]
     fn test_lf_ser_de() {
@@ -294,7 +354,7 @@ mod tests {
         let a = Frac::new(1, 2);
         let b = Frac::new(1, 2);
         let result = a + b;
-        assert_eq!(result, Frac::new(2, 2)); // 2/4 = 1/2^2
+        assert_eq!(result, Frac::new(2, 2)); // 2/2
     }
 
     #[test]
@@ -302,7 +362,7 @@ mod tests {
         let a = Frac::new(1, 2);
         let b = Frac::new(1, 3);
         let result = a + b;
-        assert_eq!(result, Frac::new(3, 3)); // 1/4 + 1/8 = 3/8 = 3/2^3
+        assert_eq!(result, Frac::new(5, 6)); // 1/2 + 1/3 = 5/6
     }
 
     #[test]
@@ -310,7 +370,7 @@ mod tests {
         let a = Frac::new(2, 2);
         let b = Frac::new(1, 2);
         let result = a - b;
-        assert_eq!(result, Frac::new(1, 2)); // 2/4 - 1/4 = 1/4 = 1/2^2
+        assert_eq!(result, Frac::new(1, 2)); // 2/2 - 1/2 = 1/2
     }
 
     #[test]
@@ -318,7 +378,7 @@ mod tests {
         let a = Frac::new(1, 2);
         let b = Frac::new(1, 3);
         let result = a - b;
-        assert_eq!(result, Frac::new(1, 3)); // 1/4 - 1/8 = 1/8 = 1/2^3
+        assert_eq!(result, Frac::new(1, 6)); // 1/2 - 1/3 = 1/6
     }
 
     #[test]
@@ -326,7 +386,7 @@ mod tests {
         let a = Frac::new(1, 2);
         let b = Frac::new(1, 3);
         let result = a * b;
-        assert_eq!(result, Frac::new(1, 5)); // 1/4 * 1/8 = 1/32 = 1/2^5
+        assert_eq!(result, Frac::new(1, 6)); // 1/2 * 1/3 = 1/6
     }
 
     #[test]
@@ -334,7 +394,7 @@ mod tests {
         let a = Frac::new(1, 2);
         let b = Frac::new(1, 3);
         let result = a / b;
-        assert_eq!(result, Frac::new(1, -1)); // 1/4 / 1/8 = 2 = 1/2^-1
+        assert_eq!(result, Frac::new(3, 2)); // 1/2 / 1/3 = 3/2
     }
 
     #[test]
@@ -346,14 +406,92 @@ mod tests {
             &[
                 Token::Struct {
                     name: "Frac",
+                    len: 1,
+                },
+                Token::Str("fraction"),
+                Token::TupleVariant {
+                    name: "GenericFraction",
+                    variant: "Rational",
                     len: 2,
                 },
-                Token::Str("numerator"),
-                Token::I32(1),
-                Token::Str("power"),
-                Token::I32(2),
+                Token::UnitVariant {
+                    name: "Sign",
+                    variant: "Plus",
+                },
+                Token::Tuple { len: 2 },
+                Token::U64(1),
+                Token::U64(2),
+                Token::TupleEnd,
+                Token::TupleVariantEnd,
                 Token::StructEnd,
             ],
         );
+    }
+
+    #[test]
+    fn frac_from_str() {
+        let frac_str = "0.5";
+        let frac = frac_str.parse::<Frac>().unwrap();
+        let expected_num = 1;
+        let expected_pow = 2;
+        let expected_frac = Frac::new(expected_num, expected_pow);
+
+        assert_eq!(frac, expected_frac)
+    }
+
+    #[test]
+    fn frac_display() {
+        let expected_frac_str = "0.5";
+        let num = 1;
+        let pow = 2;
+        let frac = Frac::new(num, pow);
+
+        let frac_str = format!("{}", frac);
+        assert_eq!(frac_str, expected_frac_str)
+    }
+
+    #[test]
+    fn frac_display_to_from_str() {
+        let num = 1;
+        let pow = 2;
+        let frac = Frac::new(num, pow);
+
+        let frac_str = format!("{}", frac);
+        let parsed_frac = frac_str.parse::<Frac>().unwrap();
+        assert_eq!(parsed_frac, frac);
+    }
+
+    #[test]
+    fn test_frac_from_f64() {
+        let value = 0.5;
+        let frac: Frac = value.into();
+        assert_eq!(frac, Frac::new(1, 2)); // 0.5 = 1/2
+
+        let value = 0.125;
+        let frac: Frac = value.into();
+        assert_eq!(frac, Frac::new(1, 8)); // 0.125 = 1/2^3
+
+        let value = 0.75;
+        let frac: Frac = value.into();
+        assert_eq!(frac, Frac::new(3, 4)); // 0.75 = 3/2^2
+
+        let value = 3.0;
+        let frac: Frac = value.into();
+        assert_eq!(frac, Frac::new(3, 1)); // 3.0 = 3/2^0
+    }
+
+    #[test]
+    fn test_f64_from_frac() {
+        let frac = Frac::new(1, 2);
+        let value: f64 = frac.into();
+        assert_eq!(value, 0.5); // 1/4
+
+        let frac = Frac::new(1, 8);
+        let value: f64 = frac.into();
+        assert_eq!(value, 0.125); // 1/8
+
+        let frac = Frac::new(3, 8);
+        let value: f64 = frac.into();
+        assert_eq!(value, 0.375); // 3/8
     }
 }

--- a/fluido/src/main.rs
+++ b/fluido/src/main.rs
@@ -3,7 +3,7 @@ mod cmd;
 use clap::Parser;
 use cmd::Args;
 use fluido_core::{Config, LogConfig, MixerGenerationConfig, MixerGenerator};
-use fluido_types::fluid::{Concentration, Fluid};
+use fluido_types::fluid::{Concentration, Fluid, Number};
 
 fn main() -> anyhow::Result<()> {
     let args = Args::try_parse()?;
@@ -29,7 +29,7 @@ fn handle_args(args: Args) -> anyhow::Result<()> {
     let config = Config::from(args);
 
     let mixer_design =
-        fluido_core::search_mixer_design(config, target_concentration, &input_space)?;
+        fluido_core::search_mixer_design::<Number>(config, target_concentration, &input_space)?;
 
     println!("best expr: {}", mixer_design.mixer_expr());
     println!("cost: {}", mixer_design.cost());


### PR DESCRIPTION
This makes the entire pipeline generic over the saturation number type, which enables easy experimentation with fractional and floats during the saturation. There are some limitations around egg, specifically `define_language!` macro which prevents me from making the language itself generic as well.